### PR TITLE
Rewrite RPC module and add RPC functions to clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ balance, err := wallet.BalanceByAddress("NKNxxxxx")
 Transfer asset to some address:
 
 ```go
-txnHash, err := wallet.Transfer(account.WalletAddress(), "100", "0")
+txnHash, err := wallet.Transfer(account.WalletAddress(), "100", nil)
 ```
 
 Open nano pay channel to specified address:
@@ -323,25 +323,25 @@ txnHash, err := wallet.SendRawTransaction(txn)
 Register name for this wallet:
 
 ```go
-txnHash, err = wallet.RegisterName("somename")
+txnHash, err = wallet.RegisterName("somename", nil)
 ```
 
 Delete name for this wallet:
 
 ```go
-txnHash, err = wallet.DeleteName("somename")
+txnHash, err = wallet.DeleteName("somename", nil)
 ```
 
 Subscribe to specified topic for this wallet for next 100 blocks:
 
 ```go
-txnHash, err = wallet.Subscribe("identifier", "topic", 100, "meta", "0")
+txnHash, err = wallet.Subscribe("identifier", "topic", 100, "meta", nil)
 ```
 
 Unsubscribe from specified topic:
 
 ```go
-txnHash, err = wallet.Unsubscribe("identifier", "topic", "0")
+txnHash, err = wallet.Unsubscribe("identifier", "topic", nil)
 ```
 
 ## iOS/Android

--- a/config.go
+++ b/config.go
@@ -198,6 +198,27 @@ func GetDefaultRPCConfig() *RPCConfig {
 	return &rpcConf
 }
 
+// TransactionConfig is the config for making a transaction.
+type TransactionConfig struct {
+	Fee        string
+	Nonce      int64 // nonce is changed to signed int for gomobile compatibility
+	Attributes []byte
+}
+
+// DefaultTransactionConfig is the default TransactionConfig.
+var DefaultTransactionConfig = TransactionConfig{
+	Fee:        "0",
+	Nonce:      0,
+	Attributes: nil,
+}
+
+// GetDefaultTransactionConfig returns the default rpc config with nil pointer
+// fields set to default.
+func GetDefaultTransactionConfig() *TransactionConfig {
+	txnConf := DefaultTransactionConfig
+	return &txnConf
+}
+
 // GetRandomSeedRPCServerAddr returns a random seed rpc server address from the
 // client config.
 func (config *ClientConfig) GetRandomSeedRPCServerAddr() string {
@@ -269,6 +290,20 @@ func MergeDialConfig(baseSessionConfig *ncp.Config, conf *DialConfig) (*DialConf
 // recursively. Any non zero value fields will override the default config.
 func MergeWalletConfig(conf *WalletConfig) (*WalletConfig, error) {
 	merged := GetDefaultWalletConfig()
+	if conf != nil {
+		err := mergo.Merge(merged, conf, mergo.WithOverride)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return merged, nil
+}
+
+// MergeTransactionConfig merges a given transaction config with the default
+// transaction config recursively. Any non zero value fields will override the
+// default config.
+func MergeTransactionConfig(conf *TransactionConfig) (*TransactionConfig, error) {
+	merged := GetDefaultTransactionConfig()
 	if conf != nil {
 		err := mergo.Merge(merged, conf, mergo.WithOverride)
 		if err != nil {

--- a/error.go
+++ b/error.go
@@ -27,6 +27,11 @@ func (e errorWithCode) Code() int32 {
 	return e.code
 }
 
+const (
+	errCodeNetworkError int32 = -1
+	errCodeDecodeError  int32 = -2
+)
+
 // Error definitions.
 var (
 	ErrClosed               = ncp.NewGenericError("use of closed network connection", true, true) // The error message is meant to be identical to error returned by net package.

--- a/examples/wallet/main.go
+++ b/examples/wallet/main.go
@@ -45,7 +45,7 @@ func main() {
 		if err != nil {
 			return err
 		}
-		txid, err := w.Transfer(address, "100", "0")
+		txid, err := w.Transfer(address, "100", nil)
 		if err != nil {
 			return err
 		}
@@ -53,7 +53,7 @@ func main() {
 
 		// Register name for this wallet
 		// This call will fail because a new account has not enough balance to pay the registration fee
-		txid, err = w.RegisterName("somename", "0")
+		txid, err = w.RegisterName("somename", nil)
 		if err != nil {
 			return err
 		}
@@ -61,7 +61,7 @@ func main() {
 
 		// Transfer name owned by this wallet to another public key
 		// This call will fail because a new account has no name
-		txid, err = w.TransferName("somename", []byte("recipient public key"), "0")
+		txid, err = w.TransferName("somename", []byte("recipient public key"), nil)
 		if err != nil {
 			return err
 		}
@@ -69,14 +69,14 @@ func main() {
 
 		// Delete name owned by this wallet
 		// This call will fail because a new account has no name
-		txid, err = w.DeleteName("somename", "0")
+		txid, err = w.DeleteName("somename", nil)
 		if err != nil {
 			return err
 		}
 		log.Println("success:", txid)
 
 		// Subscribe to bucket 0 of specified topic for this wallet for next 10 blocks
-		txid, err = w.Subscribe("identifier", "topic", 10, "meta", "0")
+		txid, err = w.Subscribe("identifier", "topic", 10, "meta", nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
1. Client and Multiclient now have all RPC functions available, including the ones that needs to send transactions. Clients will try to use connected nodes as RPC address first, and fallback to seed node if failed.
2. Transaction related function now accepts transaction config as last param, which includes fee, nonce and attributes.
