### PR TITLE
Add default go test in makefile to prevent travis build failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+.PHONY: test
+test:
+	go test ./...
+
 .PHONY: pb
 pb:
 	protoc --go_out=. payloads/*.proto


### PR DESCRIPTION
Signed-off-by: Yilun <zyl.skysniper@gmail.com>