### PR TITLE
Add *Node argument to connect and reconnect function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,14 +11,18 @@ require (
 	github.com/nknorg/nkn/v2 v2.1.7
 	github.com/nknorg/nkngomobile v0.0.0-20220615081414-671ad1afdfa9
 	github.com/patrickmn/go-cache v2.1.0+incompatible
+	github.com/stretchr/testify v1.8.1
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
 	golang.org/x/mobile v0.0.0-20230301163155-e0f57694e12c
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/itchyny/base58-go v0.0.5 // indirect
 	github.com/pbnjay/memory v0.0.0-20190104145345-974d429e7ae4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.1.0 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,7 @@ github.com/cloudflare/cloudflare-go v0.10.2/go.mod h1:qhVI5MKwBGhdNU89ZRz2plgYut
 github.com/cpu/goacmedns v0.0.2/go.mod h1:4MipLkI+qScwqtVxcNO6okBhbgRrr7/tKXUSgSL0teQ=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
@@ -210,8 +211,10 @@ github.com/kolo/xmlrpc v0.0.0-20200310150728-e0350524596b/go.mod h1:o03bZfuBwAXH
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/labbsr0x/bindman-dns-webhook v1.0.2/go.mod h1:p6b+VCXIR8NYKpDr8/dg1HKfQoRHCdcsROXKvmoehKA=
 github.com/labbsr0x/goh v1.0.1/go.mod h1:8K2UhVoaWXcCU7Lxoa2omWnC8gyW8px7/lmO61c027w=
@@ -275,6 +278,7 @@ github.com/pkg/errors v0.0.0-20190227000051-27936f6d90f9/go.mod h1:bwawxfHBFNV+L
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.2.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -317,6 +321,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/syndtr/goleveldb v1.0.1-0.20210305035536-64b5b1c73954/go.mod h1:u2MKkTVTVJWe5D1rCvame8WqhBd88EuIwODJZ1VHCPM=
 github.com/templexxx/cpufeat v0.0.0-20180724012125-cef66df7f161/go.mod h1:wM7WEvslTq+iOEAMDLSzhVuOt5BRZ05WirO+b09GHQU=
@@ -578,6 +583,7 @@ google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/l
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/multiclient.go
+++ b/multiclient.go
@@ -812,7 +812,7 @@ func (m *MultiClient) Reconnect() {
 	}
 
 	for _, client := range m.clients {
-		client.Reconnect()
+		client.Reconnect(nil)
 	}
 }
 

--- a/tests/config.go
+++ b/tests/config.go
@@ -1,0 +1,15 @@
+package tests
+
+const (
+	numMsgs        = 100
+	numClients     = 4
+	numExitMsgs    = 10
+	exitMsg        = "exit"
+	recvMsgTimeout = 10000 // milli-second
+
+	listenerId   = "Bob"
+	dialerId     = "Alice"
+	seedHex      = "e68e046d13dd911594576ba0f4a196e9666790dc492071ad9ea5972c0b940435"
+	listenerAddr = "Bob.be285ff9330122cea44487a9618f96603fde6d37d5909ae1c271616772c349fe"
+	dialerAddr   = "Alice.be285ff9330122cea44487a9618f96603fde6d37d5909ae1c271616772c349fe"
+)

--- a/tests/pub.go
+++ b/tests/pub.go
@@ -1,0 +1,226 @@
+package tests
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log"
+	"strconv"
+	"time"
+
+	nkn "github.com/nknorg/nkn-sdk-go"
+)
+
+func CreateClientConfig(retries int32) (config *nkn.ClientConfig) {
+	config = &nkn.ClientConfig{ConnectRetries: retries}
+	return
+}
+
+func CreateMessageConfig(maxHoldingSeconds int32) (config *nkn.MessageConfig) {
+	config = &nkn.MessageConfig{MaxHoldingSeconds: maxHoldingSeconds}
+	return
+}
+
+func CreateMultiClient(id, seed string, numClient int, connectFailRate int) (mc *nkn.MultiClient, err error) {
+	clientConfig := CreateClientConfig(5)
+	var byteSeed []byte
+	if len(seed) > 0 {
+		byteSeed, _ = hex.DecodeString(seed)
+	}
+	acc, err := nkn.NewAccount(byteSeed)
+	if err != nil {
+		log.Printf("nkn.NewAccount err %v", err)
+		return
+	}
+
+	// clientConfig.ConnectFailRate = connectFailRate
+	mc, err = nkn.NewMultiClient(acc, id, numClient, false, clientConfig)
+	if err != nil {
+		return
+	}
+
+	<-mc.OnConnect.C
+
+	return
+}
+
+func CreateClient(id, seed string) (client *nkn.Client, err error) {
+	clientConfig := CreateClientConfig(5)
+	var byteSeed []byte
+	if len(seed) > 0 {
+		byteSeed, _ = hex.DecodeString(seed)
+	}
+	acc, err := nkn.NewAccount(byteSeed)
+	if err != nil {
+		log.Printf("nkn.NewAccount err %v", err)
+		return
+	}
+
+	client, err = nkn.NewClient(acc, id, clientConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if node, ok := <-client.OnConnect.C; ok {
+		log.Printf("%v connects to NKN node %v, address is: %v", id, node.Addr, client.Address())
+		return
+	}
+
+	return nil, errors.New("create client fail")
+}
+
+func mcrecv(client *nkn.MultiClient, name string) (recv int, unreceived []int) {
+	recved := make(map[int]int)
+	gotExit := 0
+	for {
+		msg := client.OnMessage.NextWithTimeout(recvMsgTimeout)
+		if msg == nil {
+			break
+		}
+		if string(msg.Data) == exitMsg {
+			gotExit++
+		} else {
+			if recvedNum, err := strconv.Atoi(string(msg.Data)); err == nil {
+				if _, ok := recved[recvedNum]; !ok { // 避开重复收取的计数
+					recved[recvedNum] = 1 // record it.
+					log.Printf("%v recv: %v", name, recvedNum)
+					recv++
+				}
+			}
+		}
+
+		if gotExit >= numExitMsgs/2 && len(recved) >= numMsgs {
+			break
+		}
+	}
+
+	if len(recved) < numMsgs {
+		for i := 0; i < numMsgs; i++ {
+			if _, ok := recved[i]; !ok {
+				unreceived = append(unreceived, i)
+			}
+		}
+		log.Printf("%v recved %v, gotExit %v,  unreceived: %+v", client.Address(), recv, gotExit, unreceived)
+	}
+
+	return
+}
+
+func recv(client *nkn.Client, name string, restart bool) (recv int, unreceived []int) {
+	recved := make(map[int]int)
+	gotExit := 0
+	for {
+		msg := client.OnMessage.NextWithTimeout(recvMsgTimeout)
+		if msg == nil {
+			break
+		}
+		if string(msg.Data) == exitMsg {
+			gotExit++
+		} else {
+			if recvedNum, err := strconv.Atoi(string(msg.Data)); err == nil {
+				if _, ok := recved[recvedNum]; !ok {
+					recved[recvedNum] = 1 // record it.
+					log.Printf("%v recv: %v", name, recvedNum)
+					recv++
+				}
+			}
+		}
+
+		if gotExit >= numExitMsgs/2 && len(recved) >= numMsgs {
+			break
+		}
+
+		if restart && recv == numMsgs/2 {
+			client.GetConn().Close()
+			log.Printf("%v connection is closed", name)
+		}
+	}
+
+	if len(recved) < numMsgs {
+		for i := 0; i < numMsgs; i++ {
+			if _, ok := recved[i]; !ok {
+				unreceived = append(unreceived, i)
+			}
+		}
+		log.Printf("%v recved %v, gotExit %v,  unreceived: %+v", client.Address(), recv, gotExit, unreceived)
+	}
+
+	return
+}
+
+func send(client *nkn.Client, peer, name string, ch chan int) (sent, sendFail int) {
+	sent = 0
+	msgConfig := CreateMessageConfig(600)
+
+	for i := 1; i <= numMsgs; i++ {
+		select {
+		case <-ch: // receiver exit, no need send any more
+			return
+		default:
+		}
+
+		msg := fmt.Sprintf("%v", i)
+		_, err := client.SendText(nkn.NewStringArray(peer), msg, msgConfig)
+		if err != nil {
+			log.Printf("%v.SendText err %v\n", name, err)
+			sendFail++
+			if sendFail > numMsgs/2 {
+				break
+			}
+			continue
+		} else {
+			log.Printf("%v sent: %v", name, msg)
+			sent++
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	for i := 0; i < numExitMsgs; i++ {
+		_, err := client.SendText(nkn.NewStringArray(peer), exitMsg, nil)
+		if err != nil {
+			log.Printf("%v SendText exit err %v", name, err)
+		}
+	}
+
+	log.Printf("%v sent success: %v, fail: %v\n", name, sent, sendFail)
+
+	return
+}
+
+func mcsend(client *nkn.MultiClient, peer, name string, ch chan int) (sent, sendFail int) {
+	sent = 0
+	msgConfig := CreateMessageConfig(600)
+
+	for i := 0; i <= numMsgs; i++ {
+		select {
+		case <-ch: // receiver exit, no need send any more
+			return
+		default:
+		}
+
+		msg := fmt.Sprintf("%v", i)
+		_, err := client.SendText(nkn.NewStringArray(peer), msg, msgConfig)
+		if err != nil {
+			log.Printf("%v SendText err %v\n", name, err)
+			sendFail++
+			if sendFail > numMsgs/2 {
+				break
+			}
+			continue
+		} else {
+			log.Printf("%v sent: %v", name, msg)
+			sent++
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	for i := 0; i < numExitMsgs; i++ { // 多发几次exit，让接收端有机会收到更多的测试消息再退出
+		_, err := client.SendText(nkn.NewStringArray(peer), exitMsg, nil)
+		if err != nil {
+			log.Printf("%v SendText exit err: %v", name, err)
+		}
+	}
+
+	log.Printf("%v %v sent %v, sendFail %v\n", time.Now(), name, sent, sendFail)
+
+	return
+}

--- a/tests/send_recv_test.go
+++ b/tests/send_recv_test.go
@@ -1,0 +1,60 @@
+package tests
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// go test -v -timeout=0 -run=TestClientSendAndRecv
+func TestClientSendAndRecv(t *testing.T) {
+	listener, err := CreateClient(listenerId, seedHex)
+	require.Nil(t, err)
+
+	ch := make(chan int, 2)
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		recv(listener, listenerId, false)
+		close(ch)
+		wg.Done()
+	}()
+
+	dialer, err := CreateClient(dialerId, seedHex)
+	require.Nil(t, err)
+	wg.Add(1)
+	go func() {
+		send(dialer, listenerAddr, dialerId, ch)
+		wg.Done()
+	}()
+
+	wg.Wait()
+}
+
+// go test -v -timeout=0 -run=TestMcSendAndRecv
+func TestMcSendAndRecv(t *testing.T) {
+	listener, err := CreateMultiClient(listenerId, "", numClients, 100)
+	require.Nil(t, err)
+
+	ch := make(chan int, 2)
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		mcrecv(listener, listenerId)
+		close(ch)
+		wg.Done()
+	}()
+
+	dialer, err := CreateMultiClient(dialerId, "", numClients, 100)
+	require.Nil(t, err)
+	wg.Add(1)
+	go func() {
+		mcsend(dialer, listener.Address(), dialerId, ch)
+		wg.Done()
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
1. Add `*Node` argument to connect and reconnect function to avoid double reconnect when getting error `WRONG_NODE` ; 
2. Add test cases for client and multiclient send and receive data.